### PR TITLE
Versions jekyll

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'jekyll'
+gem 'jekyll', '2.5.3'
 gem 'rouge'
 gem 'go_script'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ PLATFORMS
 DEPENDENCIES
   go_script
   guides_style_18f
-  jekyll
+  jekyll (= 2.5.3)
   rouge
 
 BUNDLED WITH


### PR DESCRIPTION
You'll likely have to run `bundle install` when you pull this down.

@awfrancisco and I ran into a problem where using a newer version of Jekyll (3.0.0) would cause build failures locally. This happened because the Gemile only specified `jekyll` as a dependency, but the only (or, perhaps, newest) version of that gem available to Andre was `3.0.0` so bundler used that.

This versions `jekyll` at 2.5.3, which is where it was based on the Gemfile.lock already present in the repo. @mbland I don't _think_ this will cause any problems with 18F pages deployments, but we should not merge if it does. We might also want to do this for all 18F pages sites and/or upgrade Jekyll on that platform.
