### PR TITLE
Link to / directly

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ logoalt: 18F logo
 # List links that should appear in the site sidebar here
 navigation:
 - text: Introduction
-  url: index.html
+  url: /
   internal: true
 - text: Get to know 18F
   url: get-to-know-18F/


### PR DESCRIPTION
Rather than `index.html`. More future-proof URLs, and nicer to look at besides!
