### PR TITLE
Link cloud.gov

### DIFF
--- a/pages/infrastructure.md
+++ b/pages/infrastructure.md
@@ -21,7 +21,7 @@ parent: Business lines
 * Application performance monitoring (for example: New Relic)
 
 
-We have developed a Platform-as-a-Service (PaaS) called cloud.gov, based on the open source Cloud Foundry. This allows partners to create a platform where developers can deploy applications without having to worry about how their applications are run or what hardening measures are in place.
+We have developed a Platform-as-a-Service (PaaS) called [cloud.gov](https://cloud.gov), based on the open source Cloud Foundry. This allows partners to create a platform where developers can deploy applications without having to worry about how their applications are run or what hardening measures are in place.
 
 18F Infrastructure *doesn't* provide operations and maintenance (O&M) support beyond that which comes with the external service. As the partner, you're free to select the optimal provider for the type of O&M support you need.
 

--- a/pages/past-work.md
+++ b/pages/past-work.md
@@ -152,11 +152,11 @@ In addition to building custom digital services, we also develop
 platforms that make it easy for a digital team inside your agency to
 create their own site or service.
 
-### [cloud.gov](https://cloud.gov/)
+### [cloud.gov](https://cloud.gov)
 
 [![The cloud.gov homepage.]({{ site.baseurl }}/assets/images/past-work/cloud-gov.jpg)](https://cloud.gov/)
 
-cloud.gov includes a Platform-as-a-Service (PaaS) specifically built for
+[cloud.gov](https://cloud.gov) includes a Platform-as-a-Service (PaaS) specifically built for
 government, based on the open source Cloud Foundry. It provides a
 secure, scalable platform for teams to build and host their application
 or website. It can help development teams work faster and cheaper by


### PR DESCRIPTION
Adds a link to the past work section besides the header, and adds a link to the business line section on Infrastructure Services (which had none).
