### PR TITLE
fixing cloud.gov link, adding docs.cloud.gov link

### DIFF
--- a/pages/infrastructure.md
+++ b/pages/infrastructure.md
@@ -8,7 +8,7 @@ parent: Business lines
 
 18F Infrastructure also provides associated consultative and operational labor, including cost tracking, billing, and consultative assistance to inform your infrastructure management and ensure your services meet federal compliance requirements. This support allows you to focus on **designing and implementing an intelligent infrastructure** that meets your dynamic digital needs.
 
-We also have a Platform-as-a-Service product line called [cloud.gov](cloud.gov) based on open source Cloud Foundry. cloud.gov allows partners to create a platform where developers can deploy applications without having to worry about how their applications are run or what hardening measures are in place.
+We also have a Platform-as-a-Service product line called [cloud.gov](https://docs.cloud.gov/intro/overview/what-is-cloudgov/) based on open source Cloud Foundry. [cloud.gov](https://cloud.gov) allows partners to create a platform where developers can deploy applications without having to worry about how their applications are run or what hardening measures are in place. Specific documentation for cloud.gov is at this 
 
 ### What we offer
 


### PR DESCRIPTION
Fixes https://github.com/18F/intake/issues/54. Link did not point to cloud.gov.
